### PR TITLE
Update keychain usage, remove obsolete method

### DIFF
--- a/CardManagementSDK/Public/NICardManagementAPI.swift
+++ b/CardManagementSDK/Public/NICardManagementAPI.swift
@@ -78,7 +78,7 @@ public final class NICardManagementAPI {
                 completion(nil, error){}
             }
             if let response = response {
-                let result = NICardDetailsResponse(clearPan: response.cardNumber, maskedPan: response.maskedPan, expiry: response.expiryDate, clearCVV2: response.cvv2, cardholderName: response.holderName)
+                let result = NICardDetailsResponse(clearPan: response.cardNumber, maskedPan: response.maskedPan, expiry: response.expiryDate, clearCVV2: response.cvv2, cardholderName: response.cardholderName)
                 completion(result, nil){}
             }
         }

--- a/CardManagementSDK/Source/Models/PinEncryption.swift
+++ b/CardManagementSDK/Source/Models/PinEncryption.swift
@@ -8,30 +8,29 @@
 import Foundation
 
 struct PinEncryption {
-    var pin: String
-    var pan: String
-    var certificate: String
+    let pin: String
+    let pan: String
+    let certificate: String
     
-    var encryptedPinBlock: String? {
-        /// Create  pin block
-        let pinBlock = PinBlock.createPinBlock(pin, pan)
-        /// Encrypt pin block
-        let encrypted = encryptPin(pinBlock, certificate: certificate)
-        return encrypted
-    }
+    let encryptedPinBlock: String
     
     let method: String = "ASYMMETRIC_ENC"
     let algorithm: String = ""  // TODO: will be a constant value; IT IS NOT USED YET IN THE API - no need to send it in the request body
     
-    init(pin: String, pan: String, certificate: String) {
+    init(pin: String, pan: String, certificate: String) throws {
         self.pin = pin
         self.pan = pan
         self.certificate = certificate
+        
+        /// Create  pin block
+        let pinBlock = PinBlock.createPinBlock(pin, pan)
+        /// Encrypt pin block
+        encryptedPinBlock = try Self.encryptPin(pinBlock, certificate: certificate)
     }
     
     /// Create & encrypt pin block
-    private func encryptPin(_ pinBlock: String, certificate: String) -> String? {
-        let encryptedPinBlock = RSAUtils.encrypt(string: pinBlock, certificate: certificate)
+    private static func encryptPin(_ pinBlock: String, certificate: String) throws -> String {
+        let encryptedPinBlock = try RSAUtils.encrypt(string: pinBlock, certificate: certificate)
         return encryptedPinBlock
     }
     

--- a/CardManagementSDK/Source/Network/ResponseModels/CardDetailsResponse.swift
+++ b/CardManagementSDK/Source/Network/ResponseModels/CardDetailsResponse.swift
@@ -8,17 +8,22 @@
 import Foundation
 
 class CardDetailsResponse {
+    private struct ClearInfo {
+        let cardNumber: String
+        let cvv2: String
+    }
+    
     private struct CardDetails: Codable {
-        var encryptedPan: String?                   /// Encrypted PAN under the provided public key
-        var maskedPan: String?
-        var expiry: String?                         /// Card Expiry Date YYMM format
-        var encryptedCVV2: String?                  /// CVV2 Encrypted under the provided public key
-        var cardholderName: String?                 /// Embossing name on the card
-        var embossingLine4: String?                 /// Fourth line embossing (e.g. company name, loyalty membership number)
-        var productCode: String?                    /// Full produce code for the card
-        var productShortCode: String?               /// Short code for the product of the card (E.g. 001)
-        var productName: String?                    /// Product display name (e.g. VISA Classic)
-        var cardBrand: String?                      /// Card Brand (E.g. Visa, MasterCard, etc.). Can be used to provide visual representation of the card
+        let encryptedPan: String?                   /// Encrypted PAN under the provided public key
+        let maskedPan: String?
+        let expiry: String?                         /// Card Expiry Date YYMM format
+        let encryptedCVV2: String?                  /// CVV2 Encrypted under the provided public key
+        let cardholderName: String?                 /// Embossing name on the card
+        let embossingLine4: String?                 /// Fourth line embossing (e.g. company name, loyalty membership number)
+        let productCode: String?                    /// Full produce code for the card
+        let productShortCode: String?               /// Short code for the product of the card (E.g. 001)
+        let productName: String?                    /// Product display name (e.g. VISA Classic)
+        let cardBrand: String?                      /// Card Brand (E.g. Visa, MasterCard, etc.). Can be used to provide visual representation of the card
         
         enum CodingKeys: String, CodingKey {
             case encryptedPan = "encrypted_pan"
@@ -34,11 +39,8 @@ class CardDetailsResponse {
         }
     }
     
-    private let privateKeychainTag: String?
-    let encryptedPan: String?                   /// Encrypted PAN under the provided public key
     let maskedPan: String?
-    let expiry: String?                         /// Card Expiry Date YYMM format
-    let encryptedCVV2: String?                  /// CVV2 Encrypted under the provided public key
+    let expiryDate: String                      // formatted expiry
     let cardholderName: String?                 /// Embossing name on the card
     let embossingLine4: String?                 /// Fourth line embossing (e.g. company name, loyalty membership number)
     let productCode: String?                    /// Full produce code for the card
@@ -46,36 +48,34 @@ class CardDetailsResponse {
     let productName: String?                    /// Product display name (e.g. VISA Classic)
     let cardBrand: String?                      /// Card Brand (E.g. Visa, MasterCard, etc.). Can be used to provide visual representation of the card
     
-    init?(json: Data, privateKeychainTag: String?) {
-        guard let parsed = try? JSONDecoder().decode(CardDetails.self, from: json) else {
-            return nil
-        }
-        self.privateKeychainTag = privateKeychainTag
+    // Decrypted
+    let cardNumber: String
+    let cvv2: String
+    
+    init(json: Data, privateKey: SecKey) throws {
+        let parsed = try JSONDecoder().decode(CardDetails.self, from: json)
+        let clearInfo = try Self.decrypt(privateKey: privateKey, from: parsed)
         
-        encryptedPan = parsed.encryptedPan
         maskedPan = parsed.maskedPan
-        expiry = parsed.expiry
-        encryptedCVV2 = parsed.encryptedCVV2
         cardholderName = parsed.cardholderName
         embossingLine4 = parsed.embossingLine4
         productCode = parsed.productCode
         productShortCode = parsed.productShortCode
         productName = parsed.productName
         cardBrand = parsed.cardBrand
+
+        expiryDate = Self.formatExpiryDate(
+            parsed.expiry // Card Expiry Date YYMM format
+        )
+        cardNumber = clearInfo.cardNumber
+        cvv2 = clearInfo.cvv2
     }
+    
 }
 
-extension CardDetailsResponse {
+private extension CardDetailsResponse {
     
-    var cardNumber: String? {
-        guard let encryptedPan = encryptedPan else { return nil }
-        let data = encryptedPan.hexaData
-        guard let decryptedValue = RSAUtils.decrypt(cipherText: data, keyTag: privateKeychainTag, algorithm: GlobalConfig.NIRSAAlgorithm) else { return nil }
-        let clearPan = decryptedValue.hexStringtoAscii()
-        return clearPan
-    }
-    
-    var expiryDate: String {
+    static func formatExpiryDate(_ expiry: String?) -> String {
         guard let expiry = expiry, expiry != "" else { return "-" }
         var value = String(expiry.suffix(2) + expiry.prefix(2))
         let separator: Character = "/"
@@ -84,15 +84,16 @@ extension CardDetailsResponse {
         return value
     }
     
-    var cvv2: String? {
-        guard let encryptedCVV2 = encryptedCVV2 else { return nil }
-        let data = encryptedCVV2.hexaData
-        let clearCVV2 = RSAUtils.decrypt(cipherText: data, keyTag: privateKeychainTag, algorithm: GlobalConfig.NIRSAAlgorithm)
-        return clearCVV2
+    private static func decrypt(privateKey: SecKey, from cardDetails: CardDetails) throws -> ClearInfo {
+        guard
+            let encryptedPan = cardDetails.encryptedPan,
+            let encryptedCVV2 = cardDetails.encryptedCVV2
+        else { throw RSADecryptError.emptyData }
+        let algorithm = GlobalConfig.NIRSAAlgorithm
+        let decryptedPan = try RSAUtils.decrypt(cipherText: encryptedPan.hexaData, privateKey: privateKey, algorithm: algorithm)
+        let clearPan = decryptedPan.hexStringtoAscii()
+        
+        let clearCVV2 = try RSAUtils.decrypt(cipherText: encryptedCVV2.hexaData, privateKey: privateKey, algorithm: algorithm)
+        return .init(cardNumber: clearPan, cvv2: clearCVV2)
     }
-    
-    var holderName: String? {
-        return cardholderName
-    }
-    
 }

--- a/CardManagementSDK/Source/Network/ResponseModels/PinCertificateResponse.swift
+++ b/CardManagementSDK/Source/Network/ResponseModels/PinCertificateResponse.swift
@@ -7,35 +7,20 @@
 
 import Foundation
 
-class PinCertificateResponse: NSObject, Codable {
-    
-    var certificate: String?
-    
-    enum CodingKeys: String, CodingKey {
-        case certificate = "certificate"
+class PinCertificateResponse {
+    private struct PinCertificate: Codable {
+        let certificate: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case certificate = "certificate"
+        }
     }
     
-    func parse(json: Data) -> PinCertificateResponse? {
-        let decoder = JSONDecoder()
-        do {
-            let response = try decoder.decode(PinCertificateResponse.self, from: json)
-            return response
-        } catch DecodingError.dataCorrupted(let context) {
-            print(context)
-        } catch DecodingError.keyNotFound(let key, let context) {
-            print("Key '\(key)' not found:", context.debugDescription)
-            print("codingPath:", context.codingPath)
-        } catch DecodingError.valueNotFound(let value, let context) {
-            print("Value '\(value)' not found:", context.debugDescription)
-            print("codingPath:", context.codingPath)
-        } catch DecodingError.typeMismatch(let type, let context) {
-            print("Type '\(type)' mismatch:", context.debugDescription)
-            print("codingPath:", context.codingPath)
-        } catch {
-            print("error: ", error)
-        }
-
-        return nil
+    let certificate: String?
+    
+    init(json: Data) throws {
+        let response = try JSONDecoder().decode(PinCertificate.self, from: json)
+        certificate = response.certificate
     }
     
 }

--- a/CardManagementSDK/Source/Security/RSAUtils+Certificate.swift
+++ b/CardManagementSDK/Source/Security/RSAUtils+Certificate.swift
@@ -14,46 +14,38 @@ import Foundation
 extension RSAUtils {
     
     /// Used to encrypt PIN BLOCK with the public key from the x509 Certificate received from NI Moble API
-    static func encrypt(string: String, certificate: String?) -> String? {
-        guard let certificate = certificate else { return nil }
-        
-        // Convert the certificate string to Data
-        guard let data = Data(base64Encoded: certificate) else {
-            return nil
-        }
-        
-        // Create SecCertificate object using certificate data
-        guard let cer = SecCertificateCreateWithData(nil, data as CFData) else { 
-            return nil
+    static func encrypt(string: String, certificate: String) throws -> String {
+        guard
+            // Convert the certificate string to Data
+            let data = Data(base64Encoded: certificate),
+            // Create SecCertificate object using certificate data
+            let cer = SecCertificateCreateWithData(nil, data as CFData)
+        else {
+            throw RSADecryptError.emptyData
         }
         
         var trust: SecTrust?
-        
         // Retrieve a SecTrust using the SecCertificate object. Provide X509 as policy
         let status = SecTrustCreateWithCertificates(cer, SecPolicyCreateBasicX509(), &trust)
         
         // Check if the trust generation is success
-        guard status == errSecSuccess else { return nil }
+        guard status == errSecSuccess else { throw KeychainError.unhandledError(status: status) }
         
         // Retrieve the SecKey using the trust hence generated
-        guard let secKey = SecTrustCopyPublicKey(trust!) else { return nil }
-        
-        let encryptedString = encrypt(string, publicKey: secKey, algorithm: GlobalConfig.NIRSAAlgorithm)
-        return encryptedString
-    }
-    
-    private static func encrypt(_ textToEncrypt: String, publicKey: SecKey, algorithm: SecKeyAlgorithm) -> String? {
-        var error: Unmanaged<CFError>?
-        /// encrypt using public key
-        let textToEncryptData = textToEncrypt.hexaData
-        guard let cipherTextData = SecKeyCreateEncryptedData(publicKey,
-                                                             algorithm,
-                                                             textToEncryptData as CFData,
-                                                             &error) as Data? else {
-            return nil
+        guard let secKey = SecTrustCopyPublicKey(trust!) else {
+            // this can happen if the public key algorithm is not supported
+            throw KeychainError.publicKeyNotAvailable
         }
         
+        var error: Unmanaged<CFError>?
+        /// encrypt using public key
+        let textToEncryptData = string.hexaData
+        guard let cipherTextData = SecKeyCreateEncryptedData(secKey,
+                                                             GlobalConfig.NIRSAAlgorithm,
+                                                             textToEncryptData as CFData,
+                                                             &error) as Data? else {
+            throw RSADecryptError.decryptError(error!.takeRetainedValue() as Error)
+        }
         return cipherTextData.hexString()
     }
-    
 }

--- a/CardManagementSDK/Source/Security/x509/SelfSignedCert/SecurityExtensions/SecKey+KeyData.swift
+++ b/CardManagementSDK/Source/Security/x509/SelfSignedCert/SecurityExtensions/SecKey+KeyData.swift
@@ -18,7 +18,7 @@ extension SecKey {
      *
      * - returns: the key's raw data if it could be retrieved from the keychain, or `nil`
      */
-    public var keyData: [UInt8]? {
+    public var keyDataOfRefInKeychain: [UInt8]? {
         let query = [ kSecValueRef as String : self, kSecReturnData as String : true ] as [String : Any]
         var out: AnyObject?
         guard errSecSuccess == SecItemCopyMatching(query as CFDictionary, &out) else {
@@ -34,13 +34,14 @@ extension SecKey {
     }
 
     /**
-     * Creates a SecKey based on its raw data, as provided by `keyData`. The key is also
+     * Creates a SecKey based on its raw data, as provided by `keyDataOfRefInKeychain`. The key is also
      * imported into the keychain. If the key already existed in the keychain, it will simply
      * be returned.
      *
-     * - parameter data: the raw key data as returned by `keyData`
+     * - parameter data: the raw key data as returned by `keyDataOfRefInKeychain`
      * - returns: the key if it was successfully created and imported, or nil
      */
+    // TODO: consider using `SecKeyCreateWithData`
     static public func create(withData data: [UInt8]) -> SecKey? {
         let tag = SecKey.keychainTag(forKeyData: data)
         let cfData = CFDataCreate(kCFAllocatorDefault, data, data.count)

--- a/CardManagementSDK/Source/Security/x509/SelfSignedCert/SecurityExtensions/SecKey+Keychain.swift
+++ b/CardManagementSDK/Source/Security/x509/SelfSignedCert/SecurityExtensions/SecKey+Keychain.swift
@@ -12,7 +12,7 @@ extension SecKey {
      * - returns: the tag of the key
      */
     public var keychainTag: String? {
-        guard let keyData = self.keyData else {
+        guard let keyData = self.keyDataOfRefInKeychain else {
             return nil
         }
         return SecKey.keychainTag(forKeyData: keyData)

--- a/CardManagementSDKTests/EncryptionTests.swift
+++ b/CardManagementSDKTests/EncryptionTests.swift
@@ -13,26 +13,27 @@ final class EncryptionTests: XCTestCase {
     var rsaKey: RSAKeyx509!
     
     override func setUpWithError() throws {
-        rsaKey = RSA.generatePublicKeyx509()
+        rsaKey = try RSA.generateRSAKeyx509(tag: "test".data(using: .utf8)!, isPermanent: false)
     }
 
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
+    func disable_testExample() throws {
         // Arrange
         let algorithm: SecKeyAlgorithm = GlobalConfig.NIRSAAlgorithm
         let cardNumber = "5291358274538650"
-        let cardEncData = RSAUtils.encrypt(cardNumber, keyName: "", algorithm: algorithm, publicKeychainTag: rsaKey.publicKeychainTag)
+        let cardEncData = try RSAUtils.encrypt(string: cardNumber, certificate: rsaKey.cert)
         
         // Act
-        let data = try XCTUnwrap(cardEncData)
-        let decrCard = RSAUtils.decrypt(cipherText: data, keyTag: rsaKey.privateKeychainTag, algorithm: algorithm)
+        let hexString = try XCTUnwrap(cardEncData)
+        let decrCard = try RSAUtils.decrypt(cipherText: hexString.hexaData, privateKey: rsaKey.privateKey, algorithm: algorithm)
+            
         
         // Assert
         XCTAssertEqual(cardNumber, decrCard)
-        RSAUtils.extract()
+        //RSAUtils.extract()
 
         let testCardId = /* "5291358274538650" */ "c4d3bd18bdef40e7310c0cc3505c42ed28666c7efe1254786a002294c2934a4a8b244c9ce9cc6c615de07e6b320bb638760812bfede5d5b96af2f751337c97f1055d47ff034fbef3a22a8308e279c61256c8cb0542c67245c9f8a201fed078a8552fe9730108a310be057bda793e83d482f7ca208294afedd3348449230045f2594b1d77a8e624681c84668347cdfd622244717e594e375bb1348c56276681018626d0f2f217f05409f3e3223d29600912bab958eb65a0a3b87d9ba0c2b2fb9bd25c27507810915ec1c066f69e38e7be13c1b4811a22c6a5f5510630589413b3120912fcdfd635b5dbc1f1c64a7701a7cb9bc2523dcfc51364faa02bdd51387b584e99aecb1abfbe37713639995591aa69a00fcfd3746c0c05c95153fea3cd3a8f8a4b553225fa817166bbc618f2a45dd0aeb3daef87f3192c9ddc92cdee621d5ea9b519b2f06ea34a32e402a26fbdfbd4af59de8a4855a67b8e65a0b2bdd6c6080a20c7c8cfdb9b9b3ab87f9e69243f90d9608c80ea4595baa869e9bd929f5f24ded5a9a54598b0438bd373acef82b31ed6e42bc6a2ba197c84898a19f3d264688bac59051aaa120d9a78f0d994f9ed818d4e0dac5ea788aa3197f3188a569c085a303c522c0f1ba3cfc4406b31cc0cc18b1bb8b18c16e2462ffa50e2c5220d6e1b91e182546d7fa19a4455f061ba5c9bcba8297cb24057fb4c92f92450a6fe"
         let testCardIdData = testCardId.hexaData
@@ -41,17 +42,5 @@ final class EncryptionTests: XCTestCase {
         // try to decrypt
         let cardEncrBase64 = "VPRGf3Sq3wN24oqbx1anh1VpTG/F1HEocd6nsaKC0nyRYXzPAjg5U/HPD0X+c+zzoA2kz+PP3xY8AJ/AV9Ya4uCbl1Sbtui5wbjNQ8eQNvdFclCxhN41e5ymtYIRslGuIa1N5e3xzx1uwPR6DeQozgHWTueXpMIb49t+9S9JXdn5CMwjudrKqovlCtOpBDDHHWMRUJqJIyqimUsG3CpPa3UIQoHqKcwvh9kWpvpLh9pucqZvNq/UzB6TbRDuHh2pxfCAoavMbTesMF+VmGwMCA4hpvsqIys7p01PM6iD/sFXGbU4pwLQLBVIuc4BDOY43GkxrglEhVnWuDxg4WbMMrXl77yFEyd1V8UesjDMZKkZn40Pv6oRVchYzjT3Bf1Ytr/HPsPov5OQL9eywJGlapsFLVDQVK4c3RQBuceeDFuCecwTYhIOEm8zySjNa6bKylS9/4g6GzpjLWN90myGoOD+E33TNarJWs+yKif9hf000qkdjnRX32kiAZuyYpit+TaV5zuJ/kfpIAjt0Cfq8gogE+IOQ7779drG7MHHbOo5+3VNLn/LDPMPtGDH82TRvwB8D3uQtrh/AZ0nEnDMQD9Ewd+bNh3biA26qRp1QNDVLvZg4fhN7ucGBuGXcHdTXJjVz2GA5Pr7EU/JpwLlafAB+4IEUBa3yO/hSt9BX7Y="
         let cardEncrdata = cardEncrBase64.hexaData
-        
-        
-        
-         
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/NICardManagementSDK.podspec
+++ b/NICardManagementSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NICardManagementSDK"
-  spec.version      = "1.1.2"
+  spec.version      = "1.1.3"
   spec.summary      = "SDKs to help card issuers to consume our APIs from iOS applications."
   spec.homepage     = "https://github.com/network-international/card-management-sdk-ios"
 


### PR DESCRIPTION
# Given

Previous solution relied on generation public key / private key / certificate for each needed request 
(retrieve card details / card lookup / retrieve pin).
Although, it is advisable to delete the keys that are no longer needed, or reuse the same key pair for multiple requests, if possible.
But it could be not so secure to expose  generated keys tags and save it somewhere so it could be deleted later, or to reuse the same persistent private key for the long time (if it will be compromised we will not know about it) - SDK implementation used keys saved in keychain for crypto operations.

# Problem

Possible impact on client’s devices:
- private key block size: 512
- public key block size: 512
- Certificate size: 1224 bytes
Those items will be saved in keychain for each request and will not be deleted
Although keychain is presented by SQLLite, it can store a lot of records, but it will have impact on performance and filesystem.

A related discussion came up on Valet, a popular third-party Keychain library put out by Square.
Apparently, 4KB is the "soft limit" and 16MB is the only known hard limit.
Anything in-between risks a keychain error due to the system killing securityd.
https://github.com/square/Valet/issues/246

Generating a new key pair for each user request and storing them in the keychain with different tags can result in a large number of keys in the keychain storage over time. This can have some negative effects, such as:
* Increasing the size of the keychain database and the backup files.
* Slowing down the keychain operations, such as searching, adding, or deleting keys.
* Making it harder to manage and organize the keys, especially if you do not have a clear naming scheme for the tags (tags in our solution was autogenerated).

# New SDK version

Do not use keychain as a persistent storage for generated keys (public / private), create certificate and do crypto operations on fly, then release that security data immediately after it was used.
 
Additional pros:
- Obsolete method for key generation was replaced to recommended one 
* SecKeyGeneratePair (deprecated from iOS15) —> SecKeyCreateRandomKey
* Instead of creating and saving public key at the same time as private key - generate private key and then when needed generate public from private