### PR TITLE
[2.1.4] Minor updates with parsing error description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ xcschememanagement.plist
 *.xcbkptlist
 tools/temp
 Example/build/XCBuildData
+archives
+NICardManagementSDK.xcframework

--- a/CardManagementSDK/Public/PublicModels/NIErrorResponse.swift
+++ b/CardManagementSDK/Public/PublicModels/NIErrorResponse.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct NIErrorConstants {
-    static let errorCode = "error_code"
-    static let errorDescription = "error_description"
+    static let errorCode = "error_code" // resultCode
+    static let errorDescription = "error_description" // resultDescription
 }
 
 @objc public class NIErrorResponse: NSObject {
@@ -54,8 +54,17 @@ struct NIErrorConstants {
             }
             
             isError = true
-            errorCode = json[NIErrorConstants.errorCode] as? String ?? String(response.code)
-            errorMessage = json[NIErrorConstants.errorDescription] as? String ?? json[ResponseConstants.message] as? String ?? "Unknown"
+            
+            errorCode = json[NIErrorConstants.errorCode] as? String
+            ?? json["resultCode"] as? String
+            ?? String(response.code)
+            
+            errorMessage = json[NIErrorConstants.errorDescription] as? String
+            ?? json[ResponseConstants.message] as? String
+            ?? json["resultDescription"] as? String
+            ?? String(data: data, encoding: .utf8)
+            ?? "Unknown"
+            
             return self
         }
     }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - NICardManagementSDK (2.1.3)
+  - NICardManagementSDK (2.1.4)
 
 DEPENDENCIES:
   - NICardManagementSDK (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  NICardManagementSDK: 6329f879f4e6dd8433f2e68193a6ec668740593a
+  NICardManagementSDK: 4867a1a36c91b8d6942cda998292074aadc91a32
 
 PODFILE CHECKSUM: 728cf17c9caf3b85f8c7a736f40c2d76590596ae
 

--- a/Example/Pods/Local Podspecs/NICardManagementSDK.podspec.json
+++ b/Example/Pods/Local Podspecs/NICardManagementSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "NICardManagementSDK",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "summary": "SDKs to help card issuers to consume our APIs from iOS applications.",
   "homepage": "https://github.com/network-international/card-management-sdk-ios",
   "license": {
@@ -14,7 +14,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/network-international/card-management-sdk-ios.git",
-    "tag": "2.1.3"
+    "tag": "2.1.4"
   },
   "source_files": "CardManagementSDK/**/*.{swift}",
   "resources": "CardManagementSDK/**/*.{png,jpeg,jpg,storyboard,xib,xcassets,strings,otf}",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - NICardManagementSDK (2.1.3)
+  - NICardManagementSDK (2.1.4)
 
 DEPENDENCIES:
   - NICardManagementSDK (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  NICardManagementSDK: 6329f879f4e6dd8433f2e68193a6ec668740593a
+  NICardManagementSDK: 4867a1a36c91b8d6942cda998292074aadc91a32
 
 PODFILE CHECKSUM: 728cf17c9caf3b85f8c7a736f40c2d76590596ae
 

--- a/Example/Pods/Target Support Files/NICardManagementSDK/NICardManagementSDK-Info.plist
+++ b/Example/Pods/Target Support Files/NICardManagementSDK/NICardManagementSDK-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.1.3</string>
+  <string>2.1.4</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/NICardManagementSDK.podspec
+++ b/NICardManagementSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NICardManagementSDK"
-  spec.version      = "2.1.3"
+  spec.version      = "2.1.4"
   spec.summary      = "SDKs to help card issuers to consume our APIs from iOS applications."
   spec.homepage     = "https://github.com/network-international/card-management-sdk-ios"
 

--- a/NICardManagementSDK.xcworkspace/contents.xcworkspacedata
+++ b/NICardManagementSDK.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:CardManagementSDK.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/NICardManagementSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/NICardManagementSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Some services return the wrong error model that SDK cannot parse, which leads to loosing of error description